### PR TITLE
common-library: Add Kubernetes_HorizontalPodAutoscaler template

### DIFF
--- a/charts/common-library/Chart.yaml
+++ b/charts/common-library/Chart.yaml
@@ -8,5 +8,5 @@ sources:
 maintainers:
 - name: inetshell
   email: inetshell@gmail.com
-version: 1.1.19
-appVersion: 1.1.19
+version: 1.1.20
+appVersion: 1.1.20

--- a/charts/common-library/examples/Kubernetes_HorizontalPodAutoscaler.yaml
+++ b/charts/common-library/examples/Kubernetes_HorizontalPodAutoscaler.yaml
@@ -1,0 +1,19 @@
+HorizontalPodAutoscaler:
+  test-hpa:
+    labels:
+      labels: test-hpa
+    annotations:
+      annotation: test-hpa
+    scaleTargetRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: php-apache
+    minReplicas: 1
+    maxReplicas: 10
+    metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50

--- a/charts/common-library/templates/Kubernetes_HorizontalPodAutoscaler.yaml
+++ b/charts/common-library/templates/Kubernetes_HorizontalPodAutoscaler.yaml
@@ -1,0 +1,3 @@
+{{ range $name, $data := .Values.HorizontalPodAutoscaler }}
+  {{ include "library.Kubernetes.HorizontalPodAutoscaler" (dict "name" $name "data" $data "Release" $.Release "Values" $.Values "Template" $.Template ) }}
+{{ end }}

--- a/charts/common-library/templates/_Kubernetes_HorizontalPodAutoscaler.yaml
+++ b/charts/common-library/templates/_Kubernetes_HorizontalPodAutoscaler.yaml
@@ -1,0 +1,28 @@
+{{- define "library.Kubernetes.HorizontalPodAutoscaler" }}
+{{- $data := .Values.HorizontalPodAutoscaler }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .name }}
+  namespace: {{ .Release.Namespace }}
+  {{- with (index $data .name).annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  {{- with (index $data .name).labels }}
+  labels:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with (index $data .name).scaleTargetRef }}
+  scaleTargetRef:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  minReplicas: {{ (index $data .name).minReplicas | default 1 }}
+  maxReplicas: {{ (index $data .name).maxReplicas | default 3 }}
+  {{- with (index $data .name).metrics }}
+  metrics:
+    {{- tpl (toYaml .) $ | nindent 2 }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
Adds Kubernetes HorizontalPodAutoscaler  support to common-library chart.

Test command:
```
cd charts/common-library
make test file=examples/Kubernetes_HorizontalPodAutoscaler.yaml
```

Test output:
```
set -e; \
        helm lint . -f examples/Kubernetes_HorizontalPodAutoscaler.yaml --quiet; \
        helm template test-release . -f examples/Kubernetes_HorizontalPodAutoscaler.yaml;
---
# Source: common-library/templates/Kubernetes_HorizontalPodAutoscaler.yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: test-hpa
  namespace: default
  annotations:
    annotation: test-hpa
  labels:
    labels: test-hpa
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: php-apache
  minReplicas: 1
  maxReplicas: 10
  metrics:
  - resource:
      name: cpu
      target:
        averageUtilization: 50
        type: Utilization
    type: Resource
```
